### PR TITLE
fix: Avoid index signature error for paths with empty params

### DIFF
--- a/packages/openapi-typescript/src/transform/paths-object.ts
+++ b/packages/openapi-typescript/src/transform/paths-object.ts
@@ -27,7 +27,7 @@ export default function transformPathsObject(pathsObject: PathsObject, ctx: Glob
     const pathParams = new Map([...extractPathParams(pathItemObject), ...OPERATIONS.flatMap((op) => Array.from(extractPathParams(pathItemObject[op as keyof PathItemObject])))]);
 
     // build dynamic string template literal index
-    if (ctx.pathParamsAsTypes && pathParams) {
+    if (ctx.pathParamsAsTypes && pathParams.size > 0) {
       for (const p of pathParams.values()) {
         const paramType = transformParameterObject(p, { path: `#/paths/${url}/parameters/${p.name}`, ctx });
         path = path.replace(`{${p.name}}`, `\${${paramType}}`);

--- a/packages/openapi-typescript/test/paths-object.test.ts
+++ b/packages/openapi-typescript/test/paths-object.test.ts
@@ -147,4 +147,76 @@ describe("Paths Object", () => {
   };
 }`);
   });
+  test("empty params", () => {
+    const schema: PathsObject = {
+      "/api/v1/user/me": {
+        parameters: [{ name: "page", in: "query", schema: { type: "number" }, description: "Page number." }],
+        get: {
+          parameters: [],
+          responses: {
+            200: {
+              description: "OK",
+              headers: {
+                Link: {
+                  $ref: 'components["headers"]["link"]',
+                },
+              },
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      id: { type: "string" },
+                      email: { type: "string" },
+                      name: { type: "string" },
+                    },
+                    required: ["id", "email"],
+                  },
+                },
+              },
+            },
+            404: {
+              $ref: 'components["responses"]["NotFound"]',
+            },
+          },
+        },
+      },
+    };
+
+    const generated = transformPathsObject(schema, { ...options, pathParamsAsTypes: true });
+    expect(generated).toBe(`{
+  "/api/v1/user/me": {
+    get: {
+      parameters: {
+        query?: {
+          /** @description Page number. */
+          page?: number;
+        };
+      };
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            Link: components["headers"]["link"];
+          };
+          content: {
+            "application/json": {
+              id: string;
+              email: string;
+              name?: string;
+            };
+          };
+        };
+        404: components["responses"]["NotFound"];
+      };
+    };
+    parameters: {
+      query?: {
+        /** @description Page number. */
+        page?: number;
+      };
+    };
+  };
+}`);
+  });
 });


### PR DESCRIPTION
## Changes

It fixes using `--path-as-params-types` option for paths that doesn't contain a param (like `/api/user`). In that case, using the option causes generating path name as `[path: '/api/user']` and produces compiler error `An index signature parameter type cannot be a literal type or generic type. Consider using a mapped object type instead.
`

## How to Review

It fixes [this fix](https://github.com/drwpow/openapi-typescript/pull/1130). The `pathParams` variable  is already non-empty variable, but can have empty size.

## Checklist

- [ ] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (only applicable for openapi-typescript)
